### PR TITLE
Add material-ui to the list of npm keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "postinstall": "webpack -p --display none"
   },
   "keywords": [
-    "Material-UI",
+    "material-ui",
     "Fuzzy search",
     "Autosuggest",
     "React",


### PR DESCRIPTION
I would like to enable a third-party component search for Material-UI components like Gatsby is doing it with its plugins page: https://www.gatsbyjs.org/plugins/.